### PR TITLE
feat(agentboard): show configured repo slots with git info and auto-start

### DIFF
--- a/packages/agentboard/src/mux-tmux/client.ts
+++ b/packages/agentboard/src/mux-tmux/client.ts
@@ -308,6 +308,10 @@ export class TmuxClient {
     this.run(["kill-session", "-t", target]);
   }
 
+  sendKeys(target: string, keys: string): void {
+    this.run(["send-keys", "-t", target, keys, "Enter"]);
+  }
+
   // ─── Windows ───────────────────────────────────────
 
   listWindows(options?: { scope?: "all" } | { scope: "session"; target: string }): WindowInfo[] {

--- a/packages/agentboard/src/mux-tmux/provider.ts
+++ b/packages/agentboard/src/mux-tmux/provider.ts
@@ -86,6 +86,10 @@ export class TmuxProvider implements MuxProviderV1, WindowCapable, SidebarCapabl
     this.tmux.killSession(name);
   }
 
+  sendKeys(name: string, keys: string): void {
+    this.tmux.sendKeys(name, keys);
+  }
+
   setupHooks(serverHost: string, serverPort: number): void {
     const base = `http://${serverHost}:${serverPort}`;
     const hookPost = (path: string, data?: string) => {

--- a/packages/agentboard/src/runtime/config.ts
+++ b/packages/agentboard/src/runtime/config.ts
@@ -16,6 +16,10 @@ export interface AgentboardConfig {
   sidebarPosition?: "left" | "right";
   /** Tmux prefix key for sidebar toggle (default "s") */
   keybinding?: string;
+  /** Per-panel heights in the detail view */
+  detailPanelHeights?: Record<string, number>;
+  /** Absolute paths to repos the sidebar should always show, even with no active session */
+  repoSlots?: string[];
 }
 
 const DEFAULTS: AgentboardConfig = {};

--- a/packages/agentboard/src/runtime/contracts/mux.ts
+++ b/packages/agentboard/src/runtime/contracts/mux.ts
@@ -69,6 +69,7 @@ export interface MuxProviderV1 {
   getPaneCount(name: string): number;
   createSession(name?: string, dir?: string): void;
   killSession(name: string): void;
+  sendKeys(name: string, keys: string): void;
 
   // Hooks
   setupHooks(serverHost: string, serverPort: number): void;

--- a/packages/agentboard/src/runtime/index.ts
+++ b/packages/agentboard/src/runtime/index.ts
@@ -57,6 +57,7 @@ export {
 } from "./shared";
 export type {
   SessionData,
+  SlotInfo,
   ServerState,
   SessionViewed,
   ResizeNotify,

--- a/packages/agentboard/src/runtime/server/git-info.ts
+++ b/packages/agentboard/src/runtime/server/git-info.ts
@@ -2,7 +2,6 @@ import { existsSync, watch } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import { join } from "node:path";
 import consola from "consola";
-import type { SessionData } from "../shared";
 import { startSessionPoll } from "./poll";
 
 // --- Shell helpers (for git commands only) ---
@@ -262,9 +261,9 @@ function onGitHeadChange(broadcastFn: () => void): void {
   }, 200);
 }
 
-export function syncGitWatchers(sessions: SessionData[], broadcastFn: () => void): void {
+export function syncGitWatchers(dirs: { dir: string }[], broadcastFn: () => void): void {
   const currentDirs = new Set<string>();
-  for (const s of sessions) {
+  for (const s of dirs) {
     if (s.dir) currentDirs.add(s.dir);
   }
 

--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -1,5 +1,5 @@
-import { readFileSync, unlinkSync, writeFileSync, appendFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, unlinkSync, writeFileSync, appendFileSync, realpathSync } from "node:fs";
+import { join, basename } from "node:path";
 import { homedir } from "node:os";
 
 import consola from "consola";
@@ -30,6 +30,7 @@ import {
 import type {
   ServerState,
   SessionData,
+  SlotInfo,
   ClientCommand,
   SessionViewed,
   MetadataTone,
@@ -381,9 +382,41 @@ export function startServer(
 
     metadataStore.pruneSessions(new Set(sessions.map((s) => s.name)));
 
+    const liveDirs = new Set(
+      sessions.map((s) => {
+        try {
+          return realpathSync(s.dir);
+        } catch {
+          return s.dir;
+        }
+      }),
+    );
+    const slots: SlotInfo[] = [];
+    for (const dir of config.repoSlots ?? []) {
+      let resolved = dir;
+      try {
+        resolved = realpathSync(dir);
+      } catch {
+        continue; // configured slot no longer exists on disk
+      }
+      if (liveDirs.has(resolved)) continue;
+      const git = getGitInfo(resolved);
+      slots.push({
+        dir: resolved,
+        name: basename(resolved),
+        branch: git.branch,
+        isWorktree: git.isWorktree,
+        filesChanged: git.filesChanged,
+        linesAdded: git.linesAdded,
+        linesRemoved: git.linesRemoved,
+        commitsDelta: git.commitsDelta,
+      });
+    }
+
     return {
       type: "state",
       sessions,
+      slots,
       theme: currentTheme,
       sidebarWidth,
       preferredEditor,
@@ -409,7 +442,7 @@ export function startServer(
     tracker.pruneIdle(IDLE_PRUNE_MS);
     tracker.pruneSupersededByPane();
     lastState = computeState();
-    syncGitWatchers(lastState.sessions, broadcastState);
+    syncGitWatchers([...lastState.sessions, ...lastState.slots], broadcastState);
     const msg = JSON.stringify(lastState);
     server.publish("sidebar", msg);
   }
@@ -1420,7 +1453,8 @@ export function startServer(
         break;
       }
       case "new-session":
-        mux.createSession();
+        mux.createSession(cmd.name, cmd.dir);
+        if (cmd.launch === "claude" && cmd.name) mux.sendKeys(cmd.name, "claude");
         broadcastState();
         break;
       case "kill-session": {
@@ -1799,7 +1833,7 @@ export function startServer(
     broadcastState,
   });
   gitPollTimer = startGitPoll({
-    getSessions: () => lastState?.sessions ?? null,
+    getSessions: () => (lastState ? [...lastState.sessions, ...lastState.slots] : null),
     getClientCount: () => clientCount,
     broadcastState,
   });

--- a/packages/agentboard/src/runtime/shared.ts
+++ b/packages/agentboard/src/runtime/shared.ts
@@ -39,9 +39,22 @@ export interface SessionData {
   metadata?: SessionMetadata | null;
 }
 
+/** A configured repo slot with no live tmux session — git info only, no session state. */
+export interface SlotInfo {
+  dir: string;
+  name: string;
+  branch: string;
+  isWorktree: boolean;
+  filesChanged: number;
+  linesAdded: number;
+  linesRemoved: number;
+  commitsDelta: number;
+}
+
 export interface ServerState {
   type: "state";
   sessions: SessionData[];
+  slots: SlotInfo[];
   theme: string | undefined;
   sidebarWidth: number;
   preferredEditor: string;
@@ -114,7 +127,7 @@ export interface SessionMetadata {
 export type ClientCommand =
   | { type: "switch-session"; name: string }
   | { type: "switch-index"; index: number }
-  | { type: "new-session" }
+  | { type: "new-session"; dir?: string; name?: string; launch?: "claude" }
   | { type: "kill-session"; name: string }
   | { type: "reorder-session"; name: string; delta: ReorderDelta }
   | { type: "refresh" }

--- a/packages/agentboard/src/tui/components/DiffStats.tsx
+++ b/packages/agentboard/src/tui/components/DiffStats.tsx
@@ -3,7 +3,7 @@ import type { Accessor } from "solid-js";
 import type { SessionData, Theme } from "../../runtime/index";
 
 export interface DiffStatsProps {
-  session: SessionData;
+  session: Pick<SessionData, "filesChanged" | "linesAdded" | "linesRemoved" | "commitsDelta">;
   palette: Accessor<Theme["palette"]>;
 }
 

--- a/packages/agentboard/src/tui/components/SlotCard.tsx
+++ b/packages/agentboard/src/tui/components/SlotCard.tsx
@@ -1,0 +1,83 @@
+import { Show } from "solid-js";
+import type { Accessor } from "solid-js";
+import type { SlotInfo, Theme } from "../../runtime/index";
+import { truncate } from "../../runtime/index";
+import { DIM } from "../constants";
+import { DiffStats } from "./DiffStats";
+import { familyColor } from "./family-color";
+
+export interface SlotCardProps {
+  slot: SlotInfo;
+  isFocused: boolean;
+  theme: Accessor<Theme>;
+  onSelect: () => void;
+}
+
+export function SlotCard(props: SlotCardProps) {
+  const P = () => props.theme().palette;
+
+  const familyHue = () => familyColor(props.slot.name, P());
+  const nameColor = () => (props.isFocused ? P().text : familyHue());
+
+  const truncName = () => truncate(props.slot.name, 18);
+  const truncBranch = () => (props.slot.branch ? truncate(props.slot.branch, 45) : "");
+
+  const hasDiff = () => {
+    const { linesAdded, linesRemoved, commitsDelta, filesChanged } = props.slot;
+    return !!(linesAdded || linesRemoved || commitsDelta || filesChanged);
+  };
+
+  const bgColor = () => (props.isFocused ? P().surface0 : "transparent");
+
+  return (
+    <box flexDirection="column" flexShrink={0}>
+      <box
+        flexDirection="row"
+        backgroundColor={bgColor()}
+        onMouseDown={props.onSelect}
+        paddingLeft={1}
+      >
+        <text style={{ fg: props.isFocused ? P().lavender : "transparent" }}>
+          {props.isFocused ? "▌" : " "}
+        </text>
+
+        <box flexDirection="column" flexGrow={1} paddingRight={1}>
+          <box flexDirection="row" height={1}>
+            <text truncate flexGrow={1}>
+              <span style={{ fg: nameColor(), attributes: props.isFocused ? undefined : DIM }}>
+                {truncName()}
+              </span>
+            </text>
+            <Show when={hasDiff()}>
+              <box flexShrink={0} paddingLeft={1}>
+                <DiffStats session={props.slot} palette={() => P()} />
+              </box>
+            </Show>
+          </box>
+
+          <box flexDirection="row" height={1}>
+            <Show when={props.slot.branch}>
+              <text truncate flexShrink={1} flexGrow={1}>
+                <span style={{ fg: props.isFocused ? P().pink : P().overlay0 }}>
+                  {truncBranch()}
+                </span>
+              </text>
+            </Show>
+            <text flexShrink={0}>
+              <span style={{ fg: P().overlay0, attributes: DIM }}>not started</span>
+            </text>
+          </box>
+
+          <Show when={props.isFocused}>
+            <text>
+              <span style={{ fg: P().overlay1 }}>enter</span>
+              <span style={{ fg: P().overlay0 }}> start claude · </span>
+              <span style={{ fg: P().overlay1 }}>s</span>
+              <span style={{ fg: P().overlay0 }}> shell</span>
+            </text>
+          </Show>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/packages/agentboard/src/tui/index.tsx
+++ b/packages/agentboard/src/tui/index.tsx
@@ -18,11 +18,13 @@ import { ensureServer, SERVER_PORT, SERVER_HOST, resolveTheme } from "../runtime
 import type {
   ServerMessage,
   SessionData,
+  SlotInfo,
   ClientCommand,
   ReorderDelta,
   Theme,
 } from "../runtime/index";
 import { SessionCard } from "./components/SessionCard";
+import { SlotCard } from "./components/SlotCard";
 import { StatusBar } from "./components/StatusBar";
 import { detectMuxContext, refocusMainPane, getLocalSessionName } from "./mux-context";
 import { SPINNERS, BOLD, DIM, DIVIDER, logResizeDebug } from "./constants";
@@ -76,6 +78,7 @@ function App() {
   const S = () => theme().status;
 
   const [sessions, setSessions] = createStore<SessionData[]>([]);
+  const [slots, setSlots] = createStore<SlotInfo[]>([]);
   const [focusedSession, setFocusedSession] = createSignal<string | null>(null);
   const [connected, setConnected] = createSignal(false);
   const [spinIdx, setSpinIdx] = createSignal(0);
@@ -115,6 +118,17 @@ function App() {
 
   const focusedData = createMemo(() => sessions.find((s) => s.name === focusedSession()) ?? null);
 
+  // Slot rows (configured repos with no live session) share the up/down
+  // browsing focus with session rows, keyed by a "slot:<dir>" prefix so they
+  // never collide with a real session name.
+  function slotKey(dir: string): string {
+    return `slot:${dir}`;
+  }
+  const combinedRows = createMemo(() => [
+    ...sessions.map((s) => ({ key: s.name })),
+    ...slots.map((sl) => ({ key: slotKey(sl.dir) })),
+  ]);
+
   function send(cmd: ClientCommand, successMsg?: string): boolean {
     if (connected() && ws) {
       ws.send(JSON.stringify(cmd));
@@ -136,6 +150,13 @@ function App() {
     send({ type: "switch-session", name });
   }
 
+  function startSlot(slot: SlotInfo, launch?: "claude") {
+    send(
+      { type: "new-session", dir: slot.dir, name: slot.name, launch },
+      launch === "claude" ? `starting claude in ${slot.name}` : `starting shell in ${slot.name}`,
+    );
+  }
+
   function reIdentify() {
     const sessionName = getLocalSessionName(muxCtx);
     if (!sessionName) return;
@@ -146,16 +167,16 @@ function App() {
   }
 
   function moveLocalFocus(delta: -1 | 1) {
-    const list = sessions;
+    const list = combinedRows();
     if (list.length === 0) return;
 
     const current = focusedSession();
     const currentIdx = Math.max(
       0,
-      list.findIndex((s) => s.name === current),
+      list.findIndex((r) => r.key === current),
     );
     const nextIdx = Math.max(0, Math.min(list.length - 1, currentIdx + delta));
-    const next = list[nextIdx]?.name ?? null;
+    const next = list[nextIdx]?.key ?? null;
 
     if (!next || next === current) return;
 
@@ -319,14 +340,19 @@ function App() {
         batch(() => {
           if (msg.type === "state") {
             setSessions(reconcile(msg.sessions, { key: "name" }));
+            setSlots(reconcile(msg.slots, { key: "dir" }));
             // Selection is local — initialize to this sidebar's own session,
-            // and repair it if the selected session disappeared.
+            // and repair it if the selected session/slot disappeared.
             const selected = focusedSession();
-            if (!selected || !msg.sessions.some((s) => s.name === selected)) {
+            const validKeys = new Set([
+              ...msg.sessions.map((s) => s.name),
+              ...msg.slots.map((sl) => slotKey(sl.dir)),
+            ]);
+            if (!selected || !validKeys.has(selected)) {
               setFocusedSession(
                 msg.sessions.find((s) => s.name === startupSessionName)?.name ??
                   msg.sessions[0]?.name ??
-                  null,
+                  (msg.slots[0] ? slotKey(msg.slots[0].dir) : null),
               );
             }
             // Drop the optimistic switch marker if its target no longer exists.
@@ -492,7 +518,10 @@ function App() {
           activateFocusedAgent();
         } else {
           const focused = focusedSession();
-          if (focused) switchToSession(focused);
+          if (!focused) break;
+          const slot = slots.find((sl) => slotKey(sl.dir) === focused);
+          if (slot) startSlot(slot, "claude");
+          else switchToSession(focused);
         }
         break;
       }
@@ -529,6 +558,14 @@ function App() {
       case "n":
         createNewSession();
         break;
+      case "s": {
+        if (panelFocus() !== "agents") {
+          const focused = focusedSession();
+          const slot = focused ? slots.find((sl) => slotKey(sl.dir) === focused) : undefined;
+          if (slot) startSlot(slot);
+        }
+        break;
+      }
       default: {
         if (key.number) {
           const idx = Number.parseInt(key.name, 10) - 1;
@@ -616,6 +653,23 @@ function App() {
                     threadName: agent.threadName,
                   });
                 }}
+              />
+            </box>
+          )}
+        </For>
+        <For each={slots}>
+          {(slot, i) => (
+            <box flexDirection="column" flexShrink={0}>
+              <Show when={sessions.length > 0 || i() > 0}>
+                <box height={1}>
+                  <text style={{ fg: P().surface2 }}>{DIVIDER}</text>
+                </box>
+              </Show>
+              <SlotCard
+                slot={slot}
+                isFocused={isFocused(slotKey(slot.dir))}
+                theme={theme}
+                onSelect={() => setFocusedSession(slotKey(slot.dir))}
               />
             </box>
           )}
@@ -713,7 +767,8 @@ function App() {
 
 const HELP_KEYS: [string, string][] = [
   ["j/k ↑↓", "Move focus"],
-  ["Enter", "Switch to session"],
+  ["Enter", "Switch session / start claude on slot"],
+  ["s", "Start shell on focused slot"],
   ["1-9", "Jump to session"],
   ["Tab", "Cycle sessions"],
   ["n", "New session"],

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -44,6 +44,8 @@ export const AgentboardSettingsSchema = z.object({
   sidebarPosition: z.enum(["left", "right"]).optional(),
   keybinding: z.string().optional(),
   detailPanelHeights: z.record(z.string(), z.number()).optional(),
+  /** Absolute paths to repos the sidebar should always show, even with no active session */
+  repoSlots: z.array(z.string()).optional(),
 });
 
 export type AgentboardSettings = z.infer<typeof AgentboardSettingsSchema>;


### PR DESCRIPTION
## Summary
- Add `agentboard.repoSlots: string[]` config — repos to always show in the sidebar, even with no active tmux session.
- A configured slot with no live session renders as a row with git branch/diff info (reusing the existing git-info polling/watching), labeled "not started".
- Focused slot row: `Enter` creates a session there and auto-launches `claude`; `s` creates a plain shell session (new `sendKeys` primitive on the tmux mux provider).
- Sidebar up/down navigation now browses sessions and slot rows as one combined list; `Tab`/number-jump stay scoped to real sessions since there's nothing to switch to on an unstarted slot.

Ported from the "folder rail" concept in the (now-abandoned) rust/Tauri UI rewrite — decided to keep the bun/tmux app as the long-term home rather than migrate.

## Test plan
- [x] `bun typecheck`, `bun run lint`, `bun test` (343 pass), `bun run format` — all clean
- [x] `verify-app` subagent PASS
- [ ] Manual: add a slot with no session to `repoSlots`, `tt agentboard restart`, confirm row appears with correct branch/diff, `s` starts a shell, `Enter` starts a session with `claude` auto-launched

🤖 Generated with [Claude Code](https://claude.com/claude-code)