### PR TITLE
fix: move config to ~/.config/towles-tool-tmux to stop clobbering towles-tool-rs settings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 **Entry point**: `bin/run.ts` - oclif command router
 
-- Loads settings from `~/.config/towles-tool/towles-tool.settings.json`
+- Loads settings from `~/.config/towles-tool-tmux/towles-tool-tmux.settings.json`
 - Routes to oclif commands in `src/commands/`
 
 **Configuration System**:

--- a/packages/agentboard/README.md
+++ b/packages/agentboard/README.md
@@ -120,7 +120,7 @@ Solid.js app rendered via OpenTUI. Connects to server over WebSocket.
 
 ## Configuration
 
-Config file: `~/.config/towles-tool/agentboard/config.json`
+Config file: `~/.config/towles-tool-tmux/agentboard/config.json`
 
 ```json
 {

--- a/packages/agentboard/src/runtime/config.test.ts
+++ b/packages/agentboard/src/runtime/config.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { loadConfig, saveConfig, loadPreferredEditor } from "./config";
 
 const TEST_HOME = join(import.meta.dir, ".test-home");
-const CONFIG_DIR = join(TEST_HOME, ".config", "towles-tool");
-const SETTINGS_FILE = join(CONFIG_DIR, "towles-tool.settings.json");
+const CONFIG_DIR = join(TEST_HOME, ".config", "towles-tool-tmux");
+const SETTINGS_FILE = join(CONFIG_DIR, "towles-tool-tmux.settings.json");
 
 describe("config", () => {
   beforeEach(() => {

--- a/packages/agentboard/src/runtime/config.ts
+++ b/packages/agentboard/src/runtime/config.ts
@@ -20,9 +20,16 @@ export interface AgentboardConfig {
 
 const DEFAULTS: AgentboardConfig = {};
 
-function settingsPath(homeDir?: string): string {
+const TOOL_NAME = "towles-tool-tmux";
+
+/** Config directory shared by the towles-tool-tmux CLI and agentboard (~/.config/towles-tool-tmux) */
+export function configDir(homeDir?: string): string {
   const home = homeDir ?? process.env.HOME ?? process.env.USERPROFILE ?? "";
-  return join(home, ".config", "towles-tool", "towles-tool.settings.json");
+  return join(home, ".config", TOOL_NAME);
+}
+
+export function settingsPath(homeDir?: string): string {
+  return join(configDir(homeDir), `${TOOL_NAME}.settings.json`);
 }
 
 function readSettingsFile(homeDir?: string): Record<string, unknown> {
@@ -34,7 +41,7 @@ function readSettingsFile(homeDir?: string): Record<string, unknown> {
 }
 
 /**
- * Load agentboard config from ~/.config/towles-tool/towles-tool.settings.json
+ * Load agentboard config from ~/.config/towles-tool-tmux/towles-tool-tmux.settings.json
  * under the "agentboard" key.
  * @param homeDir — override home directory (for testing)
  */

--- a/packages/agentboard/src/runtime/plugins/loader.ts
+++ b/packages/agentboard/src/runtime/plugins/loader.ts
@@ -4,6 +4,7 @@ import type { MuxProvider } from "../contracts/mux";
 import type { AgentWatcher } from "../contracts/agent-watcher";
 import { MuxRegistry } from "../mux/registry";
 import { SERVER_PORT, SERVER_HOST } from "../shared";
+import { settingsPath } from "../config";
 
 /**
  * The API surface passed to every plugin factory function.
@@ -53,7 +54,7 @@ export class PluginLoader {
   }
 
   /**
-   * Load plugins from a directory (like ~/.config/towles-tool/agentboard/plugins/).
+   * Load plugins from a directory (like ~/.config/towles-tool-tmux/agentboard/plugins/).
    * Scans one level deep:
    *   - *.ts / *.js files → loaded directly
    *   - subdirs with index.ts / index.js → loaded as entry point
@@ -110,10 +111,9 @@ export class PluginLoader {
   }
 
   getSetupInfo(): { registeredMuxProviders: string[]; configPath: string; serverPort: number } {
-    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
     return {
       registeredMuxProviders: this.registry.list(),
-      configPath: join(home, ".config", "towles-tool", "towles-tool.settings.json"),
+      configPath: settingsPath(),
       serverPort: SERVER_PORT,
     };
   }

--- a/packages/agentboard/src/runtime/server/index.ts
+++ b/packages/agentboard/src/runtime/server/index.ts
@@ -13,7 +13,7 @@ import type { AgentWatcher, AgentWatcherContext } from "../contracts/agent-watch
 import { AgentTracker, instanceKey } from "../agents/tracker";
 import { SessionOrder } from "./session-order";
 import { SessionMetadataStore } from "./metadata-store";
-import { loadConfig, saveConfig, loadPreferredEditor } from "../config";
+import { loadConfig, saveConfig, loadPreferredEditor, configDir } from "../config";
 import { resolveSidebarWidthFromResizeContext, snapshotSidebarWindows } from "./sidebar-width-sync";
 import type { SidebarResizeContext, SidebarResizeSuppression } from "./sidebar-width-sync";
 import { shell, getGitInfo, syncGitWatchers, teardownGitWatchers, startGitPoll } from "./git-info";
@@ -96,8 +96,7 @@ export function startServer(
   const allWatchers = watchers ?? [];
   const tracker = new AgentTracker();
   const metadataStore = new SessionMetadataStore();
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
-  const sessionOrderPath = join(home, ".config", "towles-tool", "agentboard", "session-order.json");
+  const sessionOrderPath = join(configDir(), "agentboard", "session-order.json");
   const sessionOrder = new SessionOrder(sessionOrderPath);
 
   // Clear previous log on server start

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import consola from "consola";
 import { colors } from "consola/utils";
 
-const TOOL_NAME = "towles-tool";
+const TOOL_NAME = "towles-tool-tmux";
 
 /** Default config directory */
 export const DEFAULT_CONFIG_DIR = path.join(homedir(), ".config", TOOL_NAME);


### PR DESCRIPTION
## Summary
- This CLI shared `~/.config/towles-tool/towles-tool.settings.json` with the Rust rewrite (towles-tool-rs); `loadSettings()` stripped unknown top-level keys via Zod and rewrote the file, silently deleting Rust-side blocks (`collectors` with Slack tokens, `mcp`). This happened twice for real.
- Fix (hard cutover): this repo now uses its own config at `~/.config/towles-tool-tmux/towles-tool-tmux.settings.json`, so it can never touch the Rust CLI's file again. No migration; first run recreates defaults at the new path.
- Centralizes the agentboard config path behind `configDir()`/`settingsPath()` in `packages/agentboard/src/runtime/config.ts` (was hardcoded in 3 files), so a future rename is one edit per package.

## Test plan
- `bun run format:check`, `bun run lint`, `bun typecheck`, `bun test` — all green (331 tests)
- Verified no remaining references to the old config path outside historical docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)